### PR TITLE
Use project name as hash key

### DIFF
--- a/bin/stash-cli.js
+++ b/bin/stash-cli.js
@@ -20,7 +20,7 @@ if (command !== 'install') {
 }
 
 function log(dir, msg) {
-  console.log('stash - ' + (msg ? dir + ' - ' : '') + msg);
+  console.log('stash - ' + (msg ? dir + ' - ' + msg : dir));
 }
 
 function generateHash(s) {
@@ -32,10 +32,11 @@ function generateHash(s) {
 }
 
 function npm(dir, command, callback) {
-  log(dir, 'npm ' + command);
+  log(dir, 'npm ' + command.join(" "));
+
   var p = spawn(
     'npm',
-    [command],
+    command,
     { stdio: ['ignore', 'pipe', process.stderr] }
   );
   var out = '';
@@ -65,18 +66,19 @@ function pack(source, tarPath, callback) {
   ).on('close', callback);
 }
 
-npm(process.cwd(), 'prefix', function (err, prefix) {
+npm(process.cwd(), ['prefix'], function (err, prefix) {
   prefix = prefix.replace('\n', '');
-  npm = npm.bind(null, prefix);
+  npm = npm.bind(null, [prefix]);
 
   var projectName = require(prefix + '/package.json').name;
   var hash = generateHash(projectName);
   var tarPath = path.join(cache, hash + '.tar.gz');
   var exists = fs.existsSync(tarPath);
+  var npmInstallArgs = process.argv.slice(3);
   chain([
     exists && [unpack, tarPath, prefix],
-    exists && [npm, 'prune'],
-    [npm, 'install'],
+    exists && [npm, ['prune']],
+    [npm, ['install'].concat(npmInstallArgs)],
     [pack, prefix, tarPath]
   ], function (err, a, b) {
     if (err) {

--- a/bin/stash-cli.js
+++ b/bin/stash-cli.js
@@ -69,7 +69,8 @@ npm(process.cwd(), 'prefix', function (err, prefix) {
   prefix = prefix.replace('\n', '');
   npm = npm.bind(null, prefix);
 
-  var hash = generateHash(prefix);
+  var projectName = require(prefix + '/package.json').name;
+  var hash = generateHash(projectName);
   var tarPath = path.join(cache, hash + '.tar.gz');
   var exists = fs.existsSync(tarPath);
   chain([
@@ -81,6 +82,6 @@ npm(process.cwd(), 'prefix', function (err, prefix) {
     if (err) {
       return log(prefix, 'error:', err);
     }
-    log(prefix, 'done');
+    log(prefix, 'done for hashKey: ' + projectName);
   });
 });


### PR DESCRIPTION
On a ci pipeline tool link jenkins with changing directory names the plugin did not do its job.
We changed the hash key to the project name from the package.json.
It should be unique enough and does not change when in another directory.
Regards,
Sergej, Ben from otto.de
